### PR TITLE
Add client/.vite/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 server/uploads/
+client/.vite/


### PR DESCRIPTION
- Prevent temporary build cache data from being tracked in version control